### PR TITLE
No buffer power

### DIFF
--- a/dumux/porousmediumflow/compositional/localresidual.hh
+++ b/dumux/porousmediumflow/compositional/localresidual.hh
@@ -112,10 +112,8 @@ public:
 
             // in case one balance is substituted by the total mole balance
             if (useTotalMoleOrMassBalance) {
-            	auto compIdx = replaceCompEqIdx- conti0EqIdx;
-            	Scalar b = problem.bufferPower(scv, volVars, compIdx);
                 storage[replaceCompEqIdx] += massOrMoleDensity(volVars, phaseIdx)
-                                             *  (volVars.porosity()*volVars.saturation(phaseIdx)+b);
+                                             *  (volVars.porosity()*volVars.saturation(phaseIdx));
             }
 
             //! The energy storage in the fluid phase with index phaseIdx

--- a/dumux/porousmediumflow/compositionalCylindrical1d/localresidual.hh
+++ b/dumux/porousmediumflow/compositionalCylindrical1d/localresidual.hh
@@ -101,19 +101,17 @@ public:
             {
             	auto eqIdx = conti0EqIdx + compIdx;
             	Scalar b = problem.bufferPower(scv, volVars, compIdx);
-                if (eqIdx != replaceCompEqIdx) {
+                if (eqIdx != replaceCompEqIdx) {// all component except water
                     storage[eqIdx] += (volVars.porosity()*volVars.saturation(phaseIdx)+b)
                                       * massOrMoleDensity(volVars, phaseIdx)
                                       * massOrMoleFraction(volVars, phaseIdx, compIdx)*scv.center()[0];
                 }
             }
 
-            // in case one balance is substituted by the total mole balance
+            // for water
             if (useTotalMoleOrMassBalance) {
-            	auto compIdx = replaceCompEqIdx- conti0EqIdx;
-            	Scalar b = problem.bufferPower(scv, volVars, compIdx);
                 storage[replaceCompEqIdx] += massOrMoleDensity(volVars, phaseIdx)
-                                             *(volVars.porosity()*volVars.saturation(phaseIdx)+b)*scv.center()[0];
+                                             *(volVars.porosity()*volVars.saturation(phaseIdx))*scv.center()[0];
             }
 
             //! The energy storage in the fluid phase with index phaseIdx


### PR DESCRIPTION
The buffer power was implemented for both the water and the solute component in the functions localresidual.hh:computeStorage.
It has no significant effect on the outputs as long as the buffer power is bellow 1e7 (for a 1D axissymetric model of 0.6cm, simtime = 2d). It s unlikelly that this error had any effect on previous computation (?) but better remove it as it is still incorrect.
NB: for us  useTotalMoleOrMassBalance == true and replaceCompEqIdx == 0 == index of the water component. Thus the variation in water storage is computed after the variation in solute storage. Consequently, there is no need to change the bufferPower() function. We just have to remove the call to bufferPower() for storage[replaceCompEqIdx].
