### PR TITLE
implement choppedUpdate_ for solutes

### DIFF
--- a/dumux/porousmediumflow/richards/newtonsolver.hh
+++ b/dumux/porousmediumflow/richards/newtonsolver.hh
@@ -96,6 +96,11 @@ private:
                     // clamp the result
                     using std::clamp;
                     uCurrentIter[dofIdxGlobal][pressureIdx] = clamp(uCurrentIter[dofIdxGlobal][pressureIdx], pwMin, pwMax);
+
+                    for (int ncomp = pressureIdx +1 ;ncomp < uCurrentIter[dofIdxGlobal].size(); ncomp ++ )
+                    {
+                              uCurrentIter[dofIdxGlobal][ncomp] = std::max(uCurrentIter[dofIdxGlobal][ncomp], 0.);
+                    }
                 }
             }
         }


### PR DESCRIPTION
keep solute content >= 0, using the same method as the one implemented to keep wat. pot. within accepted bounds