### PR TITLE
add eval of mass balance for 3d and boundary flow for 1d

### DIFF
--- a/cpp/python_binding/richards10_cyl.hh
+++ b/cpp/python_binding/richards10_cyl.hh
@@ -190,11 +190,6 @@ void init_richards_10cyl(py::module &m, std::string name) {
    .def("getAvgDensity",&RichardsFoam::getAvgDensity)
    .def("numComp",&RichardsFoam::numComp)
 
-    .def_readwrite("BC_in_vals", &RichardsFoam::BC_in_vals) 
-    .def_readwrite("BC_out_vals", &RichardsFoam::BC_out_vals) 
-    .def_readwrite("BC_time", &RichardsFoam::BC_time) 
-												   
-    .def_readwrite("BC_ddt", &RichardsFoam::BC_ddt) 
 
    .def_readonly("innerIdx",&RichardsFoam::innerIdx)
    .def_readonly("outerIdx",&RichardsFoam::outerIdx)

--- a/cpp/python_binding/richards_cyl.hh
+++ b/cpp/python_binding/richards_cyl.hh
@@ -38,34 +38,7 @@ public:
     	outerIdx = this->pick({ rOut });
 	}
     
-	
-    /**
-     * for 1d3d coupling, useful to get from dumux 
-	 * the boundary flows at each time step
-	 * more accurate than getNeumann()
-	 * currently only implemented for richards_cyl
-     */
-	 
-    void clearSaveBC() {    
-        BC_in_vals.clear();
-        BC_out_vals.clear();
-        BC_time.clear();
-        BC_ddt.clear();
-    }
-    void doSaveBC(double ddt_current) {
-		int numC = this->numComp();
-        std::vector<double> BC_in_vals_i(numC);
-        std::vector<double> BC_out_vals_i(numC);
-        for(int nc = 0.; nc < numC; nc++)
-        {
-            BC_in_vals_i.at(nc) = this->getInnerFlux(nc)/this->rIn;// [ mol / (m^2 \cdot s)]_axissymmetric / [axyssimetric factor] = [ mol / (m^2 * s)]
-            BC_out_vals_i.at(nc) = this->getOuterFlux(nc)/this->rOut;// [ mol / (m^2 \cdot s)]_axissymmetric  / [axyssimetric factor] = [ mol / (m^2 * s)]
-        }
-        BC_in_vals.push_back(BC_in_vals_i);
-        BC_out_vals.push_back(BC_out_vals_i);
-        BC_ddt.push_back(ddt_current);
-    }
-	
+		
     /**
      * [ kg / (m^2 \cdot s)]
      */
@@ -123,10 +96,6 @@ public:
     double rIn = 0.;
     double rOut = 0.;
 
-    std::vector<std::vector<double>> BC_in_vals;
-    std::vector<std::vector<double>> BC_out_vals;
-    std::vector<double> BC_time;
-    std::vector<double> BC_ddt;
 };
 
 /**
@@ -163,11 +132,6 @@ void init_richards_cyl(py::module &m, std::string name) {
    .def("setRootSystemBC",&RichardsFoam::setRootSystemBC)
 
    .def("numComp",&RichardsFoam::numComp)
-
-    .def_readwrite("BC_in_vals", &RichardsFoam::BC_in_vals) 
-    .def_readwrite("BC_out_vals", &RichardsFoam::BC_out_vals) 
-    .def_readwrite("BC_time", &RichardsFoam::BC_time) 
-    .def_readwrite("BC_ddt", &RichardsFoam::BC_ddt) 
 
    .def_readonly("innerIdx",&RichardsFoam::innerIdx)
    .def_readonly("outerIdx",&RichardsFoam::outerIdx)

--- a/cpp/soil_richards/richardsproblem.hh
+++ b/cpp/soil_richards/richardsproblem.hh
@@ -74,6 +74,7 @@ public:
 	};
 
 	enum { isBox = GetPropType<TypeTag, Properties::GridGeometry>::discMethod == DiscretizationMethods::box };
+    static constexpr bool useMoles = false;
 
 	enum BCTypes {
 		constantPressure = 1,

--- a/cpp/soil_richardsnc/richards1p2cproblem.hh
+++ b/cpp/soil_richardsnc/richards1p2cproblem.hh
@@ -65,6 +65,7 @@ public:
 	using FluidSystem = GetPropType<TypeTag, Properties::FluidSystem>;
 	using EffectiveDiffusivityModel = GetPropType<TypeTag, Properties::EffectiveDiffusivityModel>;
 	static constexpr bool isBox = GridGeometry::discMethod == DiscretizationMethods::box;
+    static constexpr bool useMoles = false;
 
 	enum {		
     pressureIdx = Indices::pressureIdx, // index of primary variables

--- a/python/modules/richards.py
+++ b/python/modules/richards.py
@@ -285,8 +285,23 @@ class RichardsWrapper(SolverWrapper):
         """
         self.setBotBC(1, x)
 
+
+    def getInnerFlow(self, eqIdx = 0, length = None):
+        """ mean flow rate at the inner boundary [cm3 / day] """
+        assert self.dimWorld == 1
+        pos = np.array(self.base.getCylFaceCoordinates())
+        flux = self.getBoundaryFluxesPerFace_(eqIdx, length)
+        return flux[pos == min(pos)]
+        
+    def getOuterFlow(self, eqIdx = 0, length = None):
+        """ mean flow rate at the outer boundary [cm3 / day] """
+        assert self.dimWorld == 1
+        pos = np.array(self.base.getCylFaceCoordinates())
+        flux = self.getBoundaryFluxesPerFace_(eqIdx, length)
+        return flux[pos == max(pos)]
+        
     def getInnerFlux(self, eq_idx = 0):
-        """ [cm3 / cm2 / day] """
+        """ instantaneous flow rate at the inner boundary [cm3 / cm2 / day] """
         return self.base.getInnerFlux(eq_idx) * 24 * 3600 * 10.  # [kg m-2 s-1] = g / cm2 / day
 
     def setOuterFluxCyl(self, flux):
@@ -295,9 +310,10 @@ class RichardsWrapper(SolverWrapper):
         @param flux      [cm/day] negative means outflow    
         """
         self.setTopBC(3, flux)
-
+ 
+        
     def getOuterFlux(self, eq_idx = 0):
-        """ [cm / day]"""
+        """ instantaneous flow rate at the outer boundary  [cm / day]"""
         return self.base.getOuterFlux(eq_idx) / 1000 * 24 * 3600 * 100.  # [kg m-2 s-1] / rho = [m s-1] -> cm / day
 
     def setOuterPressure(self, value_top = 0.):
@@ -348,11 +364,34 @@ class RichardsWrapper(SolverWrapper):
         """Gets the concentration at the inner boundary [cm] """
         return self.base.getInnerSolutes(shift)
 
+    def getSource(self, eqIdx = 0):
+        """ Gathers the net sources for each cell into rank 0 as a map with global index as key [kg / cm3 / day]"""
+        self.checkGridInitialized()
+        return self._map(self._flat0(comm.gather(self.getSource_(eqIdx), root = 0)), 2) 
+
+    def getSource_(self, eqIdx = 0):
+        """nompi version of """
+        self.checkGridInitialized()
+        unitChange = 24 * 3600 / 1e6 # [ kgOrmol/m3/s -> kgOrmol/cm3/day]
+        if eqIdx == 0:
+            if self.useMoles:
+                unitChange *=  18.068 # [mol/cm3/day -> cm3/cm3/day]
+            else:
+                unitChange *= 1e3  # [kg/cm3/day -> cm3/cm3/day]
+        return np.array(self.base.getScvSources()[eqIdx]) * unitChange 
+        
+
     def setSource(self, source_map, eq_idx = 0):
         """Sets the source term as map with global cell index as key, and source as value [cm3/day] """
         self.checkGridInitialized()
         for key, value in source_map.items():
-            source_map[key] = value / 24. / 3600. / 1.e3;  # [cm3/day] -> [kg/s] (richards.hh)
+            if eq_idx == 0:
+                if self.useMoles:
+                    source_map[key] = value / 24. / 3600. / 18.068;  # [cm3/day] -> [mol/s] 
+                else:
+                    source_map[key] = value / 24. / 3600. / 1.e3;  # [cm3/day] -> [kg/s] (richards.hh)
+            else:
+                source_map[key] = value / 24. / 3600.    # [kg/day] -> [kg/s] or [mol/day] -> [mol/s]
         self.base.setSource(source_map, eq_idx)
 
     def applySource(self, dt, source_map, crit_p):

--- a/python/rhizo/soil_cyl_BoundaryFlows.py
+++ b/python/rhizo/soil_cyl_BoundaryFlows.py
@@ -1,0 +1,100 @@
+import sys; sys.path.append("../modules"); sys.path.append("../../build-cmake/cpp/python_binding/");
+sys.path.append("../../../CPlantBox");  sys.path.append("../../../CPlantBox/src")
+
+from rosi_richardsnc_cyl import RichardsNCCylFoam  # C++ part (Dumux binding)
+from richards import RichardsWrapper  # Python part
+
+import matplotlib.pyplot as plt
+from mpi4py import MPI; comm = MPI.COMM_WORLD; rank = comm.Get_rank()
+import numpy as np
+
+""" 
+Get the inner and outer boundary flows for the 1d axisymmetric soil
+"""
+
+r_in = 2  # cm
+r_out = 10
+length = 3
+
+def solve(simtimes, N):
+
+    loam = [0.08, 0.43, 0.04, 1.6, 5]  # K = 5 !
+    s = RichardsWrapper(RichardsNCCylFoam())
+
+    s.initialize()
+    s.createGrid1d(np.linspace(r_in, r_out, N))  # [cm]
+    s.setVGParameters([loam])
+
+    # theta = 0.378, benchmark is set be nearly fully saturated, so we don't care too much about the specific values
+    s.setHomogeneousIC(-1000.)  # cm pressure head
+
+    s.setTopBC("constantFluxCyl",0.1)  #  [cm/day] "noFlux")#
+    s.setBotBC("constantFluxCyl", -0.2) # "noFlux")#
+    s.setParameter("Soil.BC.Top.SType", "3")  # michaelisMenten=8 (SType = Solute Type)
+    s.setParameter("Soil.BC.Top.CValue", "-0.05")  # michaelisMenten=8 (SType = Solute Type)
+    s.setParameter("Soil.BC.Bot.SType", "3")  # michaelisMenten=8 (SType = Solute Type)
+    s.setParameter("Soil.BC.Bot.CValue", "0.1")
+
+    s.setParameter("Soil.IC.C", "0")  # g / cm3  # TODO specialised setter?
+
+    s.setParameter("Component.MolarMass", "1.8e-2") 
+
+    s.setParameter("Component.LiquidDiffusionCoefficient", "1.e-9")  # m2 s-1
+    s.initializeProblem(maxDt = 0.01)
+
+    cellVolumes = s.getCellSurfacesCyl() * length # cm3
+    if rank == 0:
+        print(s)
+
+    s.ddt = 1.e-3  # days
+
+    simtimes.insert(0, 0)
+    dt_ = np.diff(simtimes)
+    
+    for r, dt in enumerate(dt_):
+        
+
+        time = simtimes[r] 
+        print('time',time)
+            
+        #if time >= 5:
+        #    s.setSoluteTopBC([1], [0.])
+
+        if rank == 0:
+            print("*****", "#", r, "external time step", dt, " d, simulation time", s.simTime, "d, internal time step", s.ddt, "d")
+
+        Wvolbefore = cellVolumes * s.getWaterContent() # cm3
+        Smassbefore = s.getSolution(1) * (Wvolbefore / 1.e3 ) # kg
+        
+        s.solve(dt)
+        
+        Wvolafter = cellVolumes*s.getWaterContent() # cm3
+        Smassafter = s.getSolution(1) * (Wvolafter / 1.e3 ) # kg
+        
+            
+        rootSoilFluxes = s.getInnerFlow(0, length) * dt # cm3
+        rootSoilFluxesS = s.getInnerFlow(1, length) * dt # kg
+        soilSoilFluxes = s.getOuterFlow(0, length) * dt # cm3
+        soilSoilFluxesS = s.getOuterFlow(1, length) * dt # kg
+        
+        # TODO: currently, setSource not properly implemented for richards and richards 2c
+        # so left out of the mass balance.
+        # scvSources = s.getSource(0) * cellVolumes * dt # cm3
+        # scvSourcesS = s.getSource(1) * cellVolumes * dt # kg
+        
+        if rank == 0:
+            print('\tChange in water volume [cm3] per voxel:',sum(Wvolafter-Wvolbefore))
+            print('\tChange in solute mass [kg] per voxel:',sum(Smassafter-Smassbefore))
+            print('\n\n\tRMSE for water volume balance [cm3]:',np.mean(np.abs(rootSoilFluxes+soilSoilFluxes+sum(Wvolafter-Wvolbefore))))
+            print('\tRMSE for solute mass balance [kg]:',np.mean(np.abs(rootSoilFluxesS+soilSoilFluxesS+sum(Smassafter-Smassbefore))),'\n\n')
+            
+
+       
+
+
+if __name__ == "__main__":
+
+
+    simTimes = [0.5,0.78,1]  # days
+    solve(simTimes, 2)
+

--- a/python/soil/soil_massBalance3d.py
+++ b/python/soil/soil_massBalance3d.py
@@ -1,0 +1,95 @@
+import sys; sys.path.append("../modules"); sys.path.append("../../build-cmake/cpp/python_binding/");
+sys.path.append("../../../CPlantBox");  sys.path.append("../../../CPlantBox/src")
+
+from rosi_richardsnc import RichardsNCSP  # C++ part (Dumux binding)
+from richards import RichardsWrapper  # Python part
+
+import matplotlib.pyplot as plt
+from mpi4py import MPI; comm = MPI.COMM_WORLD; rank = comm.Get_rank()
+import numpy as np
+
+""" 
+How to check the soil mass and volume balance for each cell
+"""
+
+
+def solve(simtimes):
+
+    loam = [0.08, 0.43, 0.04, 1.6, 5]  # K = 5 !
+    s = RichardsWrapper(RichardsNCSP())
+
+    s.initialize()
+    s.createGrid([-5., -5., -10.], [5., 5., 0.], [2,2,2], periodic = True)  # [cm]
+    s.setVGParameters([loam])
+
+    # theta = 0.378, benchmark is set be nearly fully saturated, so we don't care too much about the specific values
+    s.setHomogeneousIC(-5000.)  # cm pressure head
+
+    s.setTopBC("constantFlux", 0.2)  #  [cm/day] "noFlux")#
+    s.setBotBC("freeDrainage") # "noFlux")#
+    s.setParameter("Soil.BC.Top.SType", "2")  # michaelisMenten=8 (SType = Solute Type)
+    s.setParameter("Soil.BC.Top.CValue", "1.e-4")  # michaelisMenten=8 (SType = Solute Type)
+    s.setParameter("Soil.BC.Bot.SType", "6")  # michaelisMenten=8 (SType = Solute Type)
+    s.setParameter("Soil.BC.Bot.CValue", "0.")
+
+    s.setParameter("Soil.IC.C", "0")  # g / cm3  # TODO specialised setter?
+
+    s.setParameter("Component.MolarMass", "1.8e-2") 
+
+    s.setParameter("Component.LiquidDiffusionCoefficient", "1.e-9")  # m2 s-1
+    s.initializeProblem(maxDt = 0.01)
+
+    # dummy sources of water and solutes to test the mass balance
+    source_map = { 0: 0.01, 1:-0.01, 2: 0.02, 3:-0.02, 4: 0.03, 5:-0.03}
+    s.setSource(source_map)
+    source_map = { 0: 0.01, 1:-0.01, 2: 0.02, 3:-0.02, 4: 0.03, 5:-0.03}
+    s.setSource(source_map, eq_idx = 1)
+    
+    if rank == 0:
+        print(s)
+
+    s.ddt = 1.e-3  # days
+
+    simtimes.insert(0, 0)
+    dt_ = np.diff(simtimes)
+    
+    for r, dt in enumerate(dt_):
+        
+
+        time = simtimes[r] 
+        print('time',time)
+            
+        #if time >= 5:
+        #    s.setSoluteTopBC([1], [0.])
+
+        if rank == 0:
+            print("*****", "#", r, "external time step", dt, " d, simulation time", s.simTime, "d, internal time step", s.ddt, "d")
+
+        Wvolbefore = s.getCellVolumes() * s.getWaterContent() # cm3
+        Smassbefore = s.getSolution(1) * (Wvolbefore / 1.e3 ) # kg
+        
+        s.solve(dt)
+        
+        Wvolafter = s.getCellVolumes()*s.getWaterContent() # cm3
+        Smassafter = s.getSolution(1) * (Wvolafter / 1.e3 ) # kg
+        
+            
+        scvFluxes = s.getFluxesPerCell(0) * dt # cm3
+        scvFluxesS = s.getFluxesPerCell(1) * dt # kg
+        scvSources = s.getSource(0) * s.getCellVolumes() * dt # cm3
+        scvSourcesS = s.getSource(1) * s.getCellVolumes() * dt # kg
+        
+        if rank == 0:
+            print('\tChange in water volume [cm3] per voxel:',Wvolafter-Wvolbefore)
+            print('\tChange in solute mass [kg] per voxel:',Smassafter-Smassbefore)
+            print('\n\n\tRMSE for water volume balance [cm3]:',np.mean(np.abs(scvFluxes+(Wvolafter-Wvolbefore)-scvSources)))
+            print('\tRMSE for solute mass balance [kg]:',np.mean(np.abs(scvFluxesS+(Smassafter-Smassbefore)-scvSourcesS)),'\n\n')
+
+
+
+if __name__ == "__main__":
+
+
+    simTimes = [0.5,0.78,1]  # days
+    solve(simTimes)
+


### PR DESCRIPTION
update so that:
1. for 3d soil (see python/soil/soil_massBalance3d.py):
1.a. the inter-cell flow can be obtained from dumux directly for python. Useful for 1d-3d coupling.
1.b. the overall mass balance error can be obtained from dumux directly for python (for accuracy check)
2. for 1d soil (see python/rhizo/soil_cyl_BoundaryFlows.py):
2.a. the mean flow at the inner and outer boundary obtained during the last 'solve' call is available.

TODO: if/when needed adapt the source() function in cpp so that it works for the 1d axissymmetric models